### PR TITLE
Fallback code block to 'text' language

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,7 @@ export function createRemarkPlugin(options = {}) {
     function blockCode(node) {
       const lang =
         ignoreUnknownLanguage && !loadedLanguages.includes(node.lang)
-          ? null
+          ? 'text'
           : node.lang;
 
       node.type = 'html';


### PR DESCRIPTION
This pull request fixes an error files where it fails to process code blocks with no language set. By changing the fallback value from `null` to `"text"`, the highlighter will continue to process even though `"text"` language may or may not exist.

Tested locally on a Next.js + MDX project by applying a patch via [`patch-package`](https://github.com/ds300/patch-package) using this patchfile:

```patch
diff --git a/node_modules/@atomiks/mdx-pretty-code/dist/mdx-pretty-code.cjs b/node_modules/@atomiks/mdx-pretty-code/dist/mdx-pretty-code.cjs
index 201983f..0755300 100644
--- a/node_modules/@atomiks/mdx-pretty-code/dist/mdx-pretty-code.cjs
+++ b/node_modules/@atomiks/mdx-pretty-code/dist/mdx-pretty-code.cjs
@@ -452,7 +452,7 @@ function createRemarkPlugin(options = {}) {
     function blockCode(node) {
       const lang =
         ignoreUnknownLanguage && !loadedLanguages.includes(node.lang)
-          ? null
+          ? "text"
           : node.lang;
 
       node.type = 'html';
diff --git a/node_modules/@atomiks/mdx-pretty-code/dist/mdx-pretty-code.js b/node_modules/@atomiks/mdx-pretty-code/dist/mdx-pretty-code.js
index 92c45eb..321322b 100644
--- a/node_modules/@atomiks/mdx-pretty-code/dist/mdx-pretty-code.js
+++ b/node_modules/@atomiks/mdx-pretty-code/dist/mdx-pretty-code.js
@@ -442,7 +442,7 @@ function createRemarkPlugin(options = {}) {
     function blockCode(node) {
       const lang =
         ignoreUnknownLanguage && !loadedLanguages.includes(node.lang)
-          ? null
+          ? "text"
           : node.lang;
 
       node.type = 'html';

```