### PR TITLE
feat: support multiple themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ mode:
 shikiOptions: {
   theme: {
     dark: JSON.parse(
-      fs.readFileSync(require.resolve("./themes/dark.json"), "utf-8")
+      fs.readFileSync(require.resolve('./themes/dark.json'), "utf-8")
     ),
     light: JSON.parse(
-      fs.readFileSync(require.resolve("./themes/light.json"), "utf-8")
+      fs.readFileSync(require.resolve('./themes/light.json'), "utf-8")
     ),
   },
 }
@@ -135,7 +135,7 @@ Now, you can use CSS to display the desired theme:
 }
 ```
 
-#### 2. Use the "css-variables" theme (Shiki version `0.9.9` and above).
+#### 2. Use the "css-variables" theme (Shiki version `0.9.9` and above)
 
 <details>
   This gives you access to CSS variable styling, which you can control across Dark
@@ -207,11 +207,11 @@ In your `MDXProvider`'s `components` prop, modify `span` like so:
 ```js
 const mdxComponents = {
   span(props) {
-    if (props["data-mdx-pretty-code"] != null) {
+    if (props['data-mdx-pretty-code'] != null) {
       return (
         <code
-          data-theme={props["data-theme"]}
-          style={{color: props["data-color"]}}
+          data-theme={props['data-theme']}
+          style={{color: props['data-color']}}
         >
           {props.children.props.children}
         </code>

--- a/README.md
+++ b/README.md
@@ -116,14 +116,9 @@ mode:
 ```
 
 The `code` elements and the inline code `<span data-mdx-pretty-code>` wrappers
-will have a class of `theme.name` (spaces will be removed, but it's otherwise up
-to you to make sure this is valid as a CSS class; default themes should already
-have a kebab-cased name).
-
-A data attribute `data-theme="[key]"` e.g `data-theme="light"` will also be
-applied. This can be useful when trying out themes, as you can target the data
-attribute `[data-theme='dark']` instead of having to update your CSS every time
-you switch themes.
+will have a data attribute `data-theme="[key]"`, e.g `data-theme="light"`. You
+can target the data attribute `[data-theme='dark']` to apply styles for that
+theme.
 
 Now, you can use CSS to display the desired theme:
 
@@ -131,13 +126,13 @@ Now, you can use CSS to display the desired theme:
 /* Query based dark mode */
 
 @media (prefers-color-scheme: dark) {
-  .my-theme {
+  [data-theme='light'] {
     display: none;
   }
 }
 
 @media (prefers-color-scheme: light), (prefers-color-scheme: no-preference) {
-  .my-other-theme {
+  [data-theme='dark'] {
     display: none;
   }
 }
@@ -146,11 +141,11 @@ Now, you can use CSS to display the desired theme:
 ```css
 /* Class based dark mode */
 
-html.dark .my-theme {
+html.dark [data-theme='dark'] {
   display: none;
 }
 
-html:not(.dark) .my-other-theme {
+html:not(.dark) [data-theme='light'] {
   display: none;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -102,17 +102,16 @@ Pass your themes to `shikiOptions.theme`, where the keys represent the color
 mode:
 
 ```js
-  shikiOptions: {
-    // Link to your VS Code theme JSON file
-    theme: {
-      dark: JSON.parse(
-        fs.readFileSync(require.resolve('./themes/my-theme.json'), 'utf-8')
-      ),
-      light: JSON.parse(
-        fs.readFileSync(require.resolve('./themes/my-other-theme.json'), 'utf-8')
-      ),
-    }
+shikiOptions: {
+  theme: {
+    dark: JSON.parse(
+      fs.readFileSync(require.resolve("./themes/dark.json"), "utf-8")
+    ),
+    light: JSON.parse(
+      fs.readFileSync(require.resolve("./themes/light.json"), "utf-8")
+    ),
   },
+}
 ```
 
 The `code` elements and the inline code `<span data-mdx-pretty-code>` wrappers
@@ -123,30 +122,16 @@ theme.
 Now, you can use CSS to display the desired theme:
 
 ```css
-/* Query based dark mode */
-
 @media (prefers-color-scheme: dark) {
-  [data-theme='light'] {
+  code[data-theme='light'] {
     display: none;
   }
 }
 
 @media (prefers-color-scheme: light), (prefers-color-scheme: no-preference) {
-  [data-theme='dark'] {
+  code[data-theme='dark'] {
     display: none;
   }
-}
-```
-
-```css
-/* Class based dark mode */
-
-html.dark [data-theme='dark'] {
-  display: none;
-}
-
-html:not(.dark) [data-theme='light'] {
-  display: none;
 }
 ```
 
@@ -160,7 +145,7 @@ Note that **this client-side theme is less granular than most other supported VS
 Code themes**. Also, be aware that this will generate unstyled code if you do
 not define these CSS variables somewhere else on your page:
 
-```css
+```html
 <style>
   :root {
     --shiki-color-text: rgb(248, 248, 242);
@@ -222,9 +207,12 @@ In your `MDXProvider`'s `components` prop, modify `span` like so:
 ```js
 const mdxComponents = {
   span(props) {
-    if (props['data-mdx-pretty-code'] != null) {
+    if (props["data-mdx-pretty-code"] != null) {
       return (
-        <code style={{color: props['data-color']}}>
+        <code
+          data-theme={props["data-theme"]}
+          style={{color: props["data-color"]}}
+        >
           {props.children.props.children}
         </code>
       );
@@ -233,6 +221,7 @@ const mdxComponents = {
     return <span {...props} />;
   },
 };
+
 ```
 
 #### Context-specific highlighting

--- a/README.md
+++ b/README.md
@@ -93,51 +93,25 @@ like Dark Mode with Shiki. See the
 [Shiki docs](https://github.com/shikijs/shiki/blob/main/docs/themes.md#dark-mode-support)
 for more info.
 
-#### 1. Use the "css-variables" theme (Shiki version `0.9.9` and above).
-
-This gives you access to CSS variable styling, which you can control across Dark
-and Light mode.
-
-Note that this client-side theme is less granular than most other supported
-VS Code themes. Also, be aware that this will generate unstyled code if you do
-not define these CSS variables somewhere else on your page:
-
-```css
-<style>
-  :root {
-    --shiki-color-text: rgb(248, 248, 242);
-    --shiki-color-background: rgb(13 13 15);
-    --shiki-token-constant: rgb(102, 217, 239);
-    --shiki-token-string: rgb(230, 219, 116);
-    --shiki-token-comment: rgb(93,93, 95);
-    --shiki-token-keyword: rgb(249, 38, 114);
-    --shiki-token-parameter: rgb(230, 219, 116);
-    --shiki-token-function: rgb(166, 226, 46);
-    --shiki-token-string-expression: rgb(230, 219, 116);
-    --shiki-token-punctuation: rgb(230, 219, 116);
-    --shiki-token-link: rgb(174, 129, 255);
-  }
-</style>
-```
-
-#### 2. Load multiple themes
+#### 1. Load multiple themes
 
 This will render duplicate code blocks for each theme. You can then hide the
 other blocks with CSS.
 
-Pass an array of themes to `shikiOptions.themes`:
+Pass your themes to `shikiOptions.theme`, where the keys represent the color
+mode:
 
 ```js
   shikiOptions: {
     // Link to your VS Code theme JSON file
-    themes: [
-      JSON.parse(
+    theme: {
+      dark: JSON.parse(
         fs.readFileSync(require.resolve('./themes/my-theme.json'), 'utf-8')
       ),
-      JSON.parse(
+      light: JSON.parse(
         fs.readFileSync(require.resolve('./themes/my-other-theme.json'), 'utf-8')
       ),
-    ],
+    }
   },
 ```
 
@@ -146,10 +120,10 @@ will have a class of `theme.name` (spaces will be removed, but it's otherwise up
 to you to make sure this is valid as a CSS class; default themes should already
 have a kebab-cased name).
 
-A class of `mdx-pretty-code-theme-[index]` e.g `mdx-pretty-code-theme-0` and
-`mdx-pretty-code-theme-1` will also be applied. This can be useful when trying
-out themes, as you can target the generic class instead of having to update your
-CSS every time you switch themes.
+A data attribute `data-theme="[key]"` e.g `data-theme="light"` will also be
+applied. This can be useful when trying out themes, as you can target the data
+attribute `[data-theme='dark']` instead of having to update your CSS every time
+you switch themes.
 
 Now, you can use CSS to display the desired theme:
 
@@ -180,6 +154,36 @@ html:not(.dark) .my-other-theme {
   display: none;
 }
 ```
+
+#### 2. Use the "css-variables" theme (Shiki version `0.9.9` and above).
+
+<details>
+  This gives you access to CSS variable styling, which you can control across Dark
+  and Light mode.
+
+Note that **this client-side theme is less granular than most other supported VS
+Code themes**. Also, be aware that this will generate unstyled code if you do
+not define these CSS variables somewhere else on your page:
+
+```css
+<style>
+  :root {
+    --shiki-color-text: rgb(248, 248, 242);
+    --shiki-color-background: rgb(13 13 15);
+    --shiki-token-constant: rgb(102, 217, 239);
+    --shiki-token-string: rgb(230, 219, 116);
+    --shiki-token-comment: rgb(93,93, 95);
+    --shiki-token-keyword: rgb(249, 38, 114);
+    --shiki-token-parameter: rgb(230, 219, 116);
+    --shiki-token-function: rgb(166, 226, 46);
+    --shiki-token-string-expression: rgb(230, 219, 116);
+    --shiki-token-punctuation: rgb(230, 219, 116);
+    --shiki-token-link: rgb(174, 129, 255);
+  }
+</style>
+```
+
+</details>
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,101 @@ module.exports = {
 };
 ```
 
+## Multiple Themes (dark/light mode)
+
+Because Shiki generates themes at build time, client-side theme switching
+support is not built in. There are two popular options for supporting something
+like Dark Mode with Shiki. See the
+[Shiki docs](https://github.com/shikijs/shiki/blob/main/docs/themes.md#dark-mode-support)
+for more info.
+
+#### 1. Use the "css-variables" theme (Shiki version `0.9.9` and above).
+
+This gives you access to CSS variable styling, which you can control across Dark
+and Light mode.
+
+Note that this client-side theme is less granular than most other supported
+VSCode themes. Also, be aware that this will generate unstyled code if you do
+not define these CSS variables somewhere else on your page:
+
+```css
+<style>
+  :root {
+    --shiki-color-text: rgb(248, 248, 242);
+    --shiki-color-background: rgb(13 13 15);
+    --shiki-token-constant: rgb(102, 217, 239);
+    --shiki-token-string: rgb(230, 219, 116);
+    --shiki-token-comment: rgb(93,93, 95);
+    --shiki-token-keyword: rgb(249, 38, 114);
+    --shiki-token-parameter: rgb(230, 219, 116);
+    --shiki-token-function: rgb(166, 226, 46);
+    --shiki-token-string-expression: rgb(230, 219, 116);
+    --shiki-token-punctuation: rgb(230, 219, 116);
+    --shiki-token-link: rgb(174, 129, 255);
+  }
+</style>
+```
+
+#### 2. Load multiple themes
+
+This will render duplicate code blocks for each theme. You can then hide the
+other blocks with css.
+
+Pass an array of themes to `shikiOptions.themes`
+
+```js
+  shikiOptions: {
+    // Link to your VS Code theme JSON file
+    themes: [
+    JSON.parse(
+      fs.readFileSync(require.resolve('./themes/my-theme.json'), 'utf-8')
+    ),
+    JSON.parse(
+      fs.readFileSync(require.resolve('./themes/my-other-theme.json'), 'utf-8')
+    )],
+  },
+```
+
+The `code` elements and the inline code `<span data-mdx-pretty-code>` wrappers
+will have a class of `theme.name` (spaces will be removed, but it's otherwise up
+to you to make sure this is valid as a css class; default themes should already
+havbe a kebab-cased name).
+
+A class of `mdx-pretty-code-theme-[index]` e.g `mdx-pretty-code-theme-0` and
+`mdx-pretty-code-theme-1` will also be applied. This can be useful when trying
+out themes, as you can target the generic class instead of having to update your
+css every time you switch themes.
+
+Now, you can use css to display the desired theme:
+
+```css
+/* Query based dark mode */
+
+@media (prefers-color-scheme: dark) {
+  .my-theme {
+    display: none;
+  }
+}
+
+@media (prefers-color-scheme: light), (prefers-color-scheme: no-preference) {
+  .my-other-theme {
+    display: none;
+  }
+}
+```
+
+```css
+/* Class based dark mode */
+
+html.dark .my-theme {
+  display: none;
+}
+
+html:not(.dark) .my-other-theme {
+  display: none;
+}
+```
+
 ## API
 
 Code blocks are configured via the meta string after the top codeblock fence.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ module.exports = {
 };
 ```
 
-## Multiple Themes (dark/light mode)
+## Multiple themes (dark/light mode)
 
 Because Shiki generates themes at build time, client-side theme switching
 support is not built in. There are two popular options for supporting something
@@ -99,7 +99,7 @@ This gives you access to CSS variable styling, which you can control across Dark
 and Light mode.
 
 Note that this client-side theme is less granular than most other supported
-VSCode themes. Also, be aware that this will generate unstyled code if you do
+VS Code themes. Also, be aware that this will generate unstyled code if you do
 not define these CSS variables somewhere else on your page:
 
 ```css
@@ -123,34 +123,35 @@ not define these CSS variables somewhere else on your page:
 #### 2. Load multiple themes
 
 This will render duplicate code blocks for each theme. You can then hide the
-other blocks with css.
+other blocks with CSS.
 
-Pass an array of themes to `shikiOptions.themes`
+Pass an array of themes to `shikiOptions.themes`:
 
 ```js
   shikiOptions: {
     // Link to your VS Code theme JSON file
     themes: [
-    JSON.parse(
-      fs.readFileSync(require.resolve('./themes/my-theme.json'), 'utf-8')
-    ),
-    JSON.parse(
-      fs.readFileSync(require.resolve('./themes/my-other-theme.json'), 'utf-8')
-    )],
+      JSON.parse(
+        fs.readFileSync(require.resolve('./themes/my-theme.json'), 'utf-8')
+      ),
+      JSON.parse(
+        fs.readFileSync(require.resolve('./themes/my-other-theme.json'), 'utf-8')
+      ),
+    ],
   },
 ```
 
 The `code` elements and the inline code `<span data-mdx-pretty-code>` wrappers
 will have a class of `theme.name` (spaces will be removed, but it's otherwise up
-to you to make sure this is valid as a css class; default themes should already
-havbe a kebab-cased name).
+to you to make sure this is valid as a CSS class; default themes should already
+have a kebab-cased name).
 
 A class of `mdx-pretty-code-theme-[index]` e.g `mdx-pretty-code-theme-0` and
 `mdx-pretty-code-theme-1` will also be applied. This can be useful when trying
 out themes, as you can target the generic class instead of having to update your
-css every time you switch themes.
+CSS every time you switch themes.
 
-Now, you can use css to display the desired theme:
+Now, you can use CSS to display the desired theme:
 
 ```css
 /* Query based dark mode */

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,18 @@
+interface shikiOptions {
+  [key: string]: any;
+}
+interface shikiOptionsWithTheme extends shikiOptions {
+  theme: JSON | string;
+  themes?: never;
+}
+interface shikiOptionsWithThemes extends shikiOptions {
+  themes: (JSON | string)[];
+  theme?: never;
+}
+
 export type Options = {
   sanitizeOptions: any;
-  shikiOptions: {
-    theme: JSON | string;
-    [key: string]: any;
-  };
+  shikiOptions: shikiOptionsWithTheme | shikiOptionsWithThemes;
   tokensMap: {[key: string]: string};
   onVisitLine(node: Element): void;
   onVisitHighlightedLine(node: Element): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,9 @@
+type theme = JSON | string;
+
 export type Options = {
   sanitizeOptions: any;
   shikiOptions: {
-    theme: JSON | string;
+    theme: theme | Record<any, theme>;
     [key: string]: any;
   };
   tokensMap: {[key: string]: string};

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,18 +1,9 @@
-interface shikiOptions {
-  [key: string]: any;
-}
-interface shikiOptionsWithTheme extends shikiOptions {
-  theme: JSON | string;
-  themes?: never;
-}
-interface shikiOptionsWithThemes extends shikiOptions {
-  themes: (JSON | string)[];
-  theme?: never;
-}
-
 export type Options = {
   sanitizeOptions: any;
-  shikiOptions: shikiOptionsWithTheme | shikiOptionsWithThemes;
+  shikiOptions: {
+    theme: JSON | string;
+    [key: string]: any;
+  };
   tokensMap: {[key: string]: string};
   onVisitLine(node: Element): void;
   onVisitHighlightedLine(node: Element): void;

--- a/src/index.js
+++ b/src/index.js
@@ -8,10 +8,6 @@ import sanitizeHtml from 'sanitize-html';
 const highlighterCache = new Map();
 
 function getThemesFromSettings(settings) {
-  if (!settings.theme)
-    throw new Error(
-      'MDX Pretty Code: no theme was specified in shikiOptions.theme'
-    );
   if (
     typeof settings.theme === 'string' ||
     settings.theme?.hasOwnProperty('tokenColors')
@@ -28,12 +24,10 @@ function highlightersFromSettings(settings) {
   return Promise.all(
     Object.keys(themes).map(async (key) => {
       const theme = themes[key];
-      const themeName = theme.name || (typeof theme === 'string' ? theme : '');
       const highlighter = await shiki.getHighlighter({
         ...settings,
         theme,
       });
-      highlighter.themeName = themeName.replace(/\s/g, '');
       highlighter.themeKey = key;
       return highlighter;
     })
@@ -45,7 +39,7 @@ export function createRemarkPlugin(options = {}) {
     const {
       sanitizeOptions = {
         allowedAttributes: {
-          code: ['style', 'data-language', 'data-theme', 'class'],
+          code: ['style', 'data-language', 'data-theme'],
           span: [
             'data-color',
             'data-mdx-pretty-code',
@@ -130,10 +124,7 @@ export function createRemarkPlugin(options = {}) {
         return sanitizeHtml(
           `<span data-mdx-pretty-code data-color="${color}" data-theme="${
             highlighter.themeKey
-          }" class="${highlighter.themeClass}"><span>${node.value.replace(
-            /{:[a-zA-Z.-]+}/,
-            ''
-          )}</span></span>`,
+          }"><span>${node.value.replace(/{:[a-zA-Z.-]+}/, '')}</span></span>`,
           sanitizeOptions
         );
       }
@@ -147,7 +138,7 @@ export function createRemarkPlugin(options = {}) {
       const pre = dom.window.document.querySelector('pre');
 
       return sanitizeHtml(
-        `<span data-mdx-pretty-code data-theme="${highlighter.themeKey}" class="${highlighter.themeClass}">${pre.innerHTML}</span>`,
+        `<span data-mdx-pretty-code data-theme="${highlighter.themeKey}">${pre.innerHTML}</span>`,
         sanitizeOptions
       );
     }
@@ -215,7 +206,6 @@ export function createRemarkPlugin(options = {}) {
 
       code.setAttribute('data-language', lang);
       code.setAttribute('data-theme', highlighter.themeKey);
-      highlighter.themeName && code.classList.add(highlighter.themeName);
       return sanitizeHtml(dom.window.document.body.innerHTML, sanitizeOptions);
     }
   };


### PR DESCRIPTION
This PR adds optional support for an array of themes in `shikiOptions.themes`.

The result is multiple code blocks/lines are created for each theme, which can be hidden with css depending on the current color mode.

The implementation is based on `remark-shiki-twoslash`'s https://github.com/shikijs/twoslash/blob/60b638e1299e51bb4cff6cc7484395c67d52a99f/packages/remark-shiki-twoslash/src/index.ts

Also added some docs from https://github.com/shikijs/shiki/blob/main/docs/themes.md#dark-mode-support which outlines the `css-variables` alternative.