### PR TITLE
chore: add repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "author": "",
   "license": "MIT",
+  "repository": "github:atomiks/mdx-pretty-code",
   "prettier": {
     "bracketSpacing": false,
     "singleQuote": true,


### PR DESCRIPTION
In addition to the obvious benefit, it's needed for the `npm repo <pkg>` command which I often use to quickly find the changelog when I see that a package has new releases after running `npm outdated`. 😃 